### PR TITLE
Fix AgentNetBench evaluator scoring edge cases

### DIFF
--- a/evaluation/agentnetbench/README.md
+++ b/evaluation/agentnetbench/README.md
@@ -13,7 +13,7 @@ Qwen matching substrings (case-insensitive): `qwen2.5-vl`, `qwen-vl`, `qwen25vl`
 - Packages:
   - openai (>=1.0.0)
   - pillow
-  - editdistance (auto-installed by the evaluator if missing)
+  - editdistance (optional; the evaluator falls back to a built-in edit-distance implementation if missing)
 
 Install:
 ```bash
@@ -53,6 +53,16 @@ Minimal trajectory schema (example):
 Notes:
 - Coordinates are relative (0–1). When metadata bounding boxes are available, evaluation accepts any click/move that falls inside the bbox.
 - For write+enter sequences, the evaluator merges them for robust scoring.
+- The evaluator does not install packages at import time. Missing optional
+  `editdistance` uses a built-in fallback so offline re-evaluation does not
+  mutate the runtime environment.
+- `press` and `hotkey` compare normalized key sequences while preserving order
+  and repeated keys.
+- `scroll` compares direction and amount. Opposite-direction scrolls receive no
+  credit; same-direction numeric scrolls receive an amount-ratio score.
+- Extra predicted actions are penalized by `len(ground_truth_actions) /
+  len(predicted_actions)`, preventing a correct first action followed by
+  unrelated actions from receiving full credit.
 
 ### Run evaluation
 ```bash
@@ -93,9 +103,8 @@ python reeval.py \
 
 ### Troubleshooting
 - openai import warnings in your IDE: install `openai>=1.0.0`.
-- editdistance missing: it is installed on-the-fly by the evaluator; you can also `pip install editdistance` manually.
+- editdistance missing: the evaluator uses a built-in fallback; you can also `pip install editdistance` manually for faster write-action scoring.
 - No results or low scores: ensure `--image_dir` points to the correct images and your model name triggers the intended agent.
 
 ### License
 This repository is intended for research and benchmarking. Please review the project’s root-level license for terms.
-

--- a/evaluation/agentnetbench/eval.py
+++ b/evaluation/agentnetbench/eval.py
@@ -3,15 +3,11 @@ from collections import defaultdict
 import math
 from typing import Dict, List, Tuple, Any
 
-# Import editdistance package for improved text comparison
 try:
     import editdistance
 except ImportError:
-    print("Warning: editdistance package not found. Installing...")
-    import subprocess
-    import sys
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "editdistance"])
-    import editdistance
+    editdistance = None
+
 
 class ActionEvaluator:
     """Class to evaluate predicted actions against ground truth actions."""
@@ -21,6 +17,83 @@ class ActionEvaluator:
         self.COORD_THRESHOLD = 0.01 * 2 ** 0.5
         self.ALPHA = 120
         self.WRITE_SIMILARITY_THRESHOLD = 0.8
+
+    def edit_distance(self, left: str, right: str) -> int:
+        """Return Levenshtein distance without mutating the runtime environment."""
+        if editdistance is not None:
+            return editdistance.eval(left, right)
+
+        if left == right:
+            return 0
+        if not left:
+            return len(right)
+        if not right:
+            return len(left)
+
+        previous = list(range(len(right) + 1))
+        for i, left_char in enumerate(left, start=1):
+            current = [i]
+            for j, right_char in enumerate(right, start=1):
+                insertion = current[j - 1] + 1
+                deletion = previous[j] + 1
+                substitution = previous[j - 1] + (left_char != right_char)
+                current.append(min(insertion, deletion, substitution))
+            previous = current
+        return previous[-1]
+
+    def normalize_keys(self, keys: Any) -> List[str]:
+        """Normalize key sequences while preserving order and repeated keys."""
+        if isinstance(keys, list):
+            return [str(key).lower() for key in keys]
+        if keys in (None, ""):
+            return []
+        return [str(keys).lower()]
+
+    def scroll_direction(self, value: Any) -> int:
+        """Return -1 for down/negative, 1 for up/positive, 0 if unknown."""
+        if isinstance(value, (int, float)):
+            if value > 0:
+                return 1
+            if value < 0:
+                return -1
+            return 0
+
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"up", "positive"}:
+                return 1
+            if normalized in {"down", "negative"}:
+                return -1
+            try:
+                return self.scroll_direction(float(normalized))
+            except ValueError:
+                return 0
+        return 0
+
+    def scroll_score(self, predicted: Any, ground_truth: Dict[str, Any]) -> float:
+        """Score scroll direction and amount instead of action type only."""
+        gt_params = ground_truth.get("params", {})
+        gt_amount = gt_params.get("amount", gt_params.get("pixels"))
+        gt_direction = self.scroll_direction(
+            gt_amount if gt_amount is not None else gt_params.get("direction")
+        )
+        pred_direction = self.scroll_direction(predicted)
+
+        if gt_direction and pred_direction and gt_direction != pred_direction:
+            return 0.0
+        if gt_direction and not pred_direction:
+            return 0.0
+
+        if isinstance(predicted, (int, float)) and isinstance(gt_amount, (int, float)):
+            pred_amount = abs(float(predicted))
+            true_amount = abs(float(gt_amount))
+            if pred_amount == 0 and true_amount == 0:
+                return 1.0
+            if pred_amount == 0 or true_amount == 0:
+                return 0.0
+            return min(pred_amount, true_amount) / max(pred_amount, true_amount)
+
+        return 1.0 if gt_direction == pred_direction else 0.0
 
     def is_point_in_bbox(self, x: float, y: float, bbox: List[float]) -> bool:
         """Check if a point (x,y) is inside a bounding box.
@@ -135,14 +208,23 @@ class ActionEvaluator:
         # Use processed actions for evaluation
         ground_truth = processed_gt
         predictions = processed_pred
+        action_count_penalty = 1.0
+        if len(predictions) > len(ground_truth):
+            action_count_penalty = len(ground_truth) / len(predictions)
 
         scores = defaultdict(float)
         action_counts = defaultdict(int)
 
         # Handle terminate action
         if ground_truth[0]['type'] == 'terminate':
-            if predictions[0][0] == 'terminate' and predictions[0][1] == ground_truth[0]['params']['status']:
-                return {"total": 1.0, "actions": {"terminate": 1.0}}
+            if (
+                predictions[0][0] == 'terminate'
+                and predictions[0][1] == ground_truth[0]['params']['status']
+            ):
+                return {
+                    "total": 1.0 * action_count_penalty,
+                    "actions": {"terminate": 1.0 * action_count_penalty}
+                }
             else:
                 return {"total": 0.0, "actions": {"terminate": 0.0}}
 
@@ -247,7 +329,7 @@ class ActionEvaluator:
                 if max_len == 0:
                     similarity = 1.0
                 else:
-                    edit_dist = editdistance.eval(p_val, g_content)
+                    edit_dist = self.edit_distance(p_val, g_content)
                     similarity = 1.0 - (edit_dist / max_len)
                     
                     if g_has_newline != p_has_newline:
@@ -263,34 +345,25 @@ class ActionEvaluator:
             elif g_type in ['press', 'hotkey']:
                 g_keys = gt['params'].get('keys', [])
                 
-                # Handle press and hotkey actions more flexibly
                 if isinstance(p_val, list) and isinstance(g_keys, list):
-                    # Normalize keys to lowercase only
-                    normalized_p_keys = [k.lower() for k in p_val]
-                    normalized_g_keys = [k.lower() for k in g_keys]
-                    
-                    # Check if key sets match (ignoring order)
-                    p_key_set = set(normalized_p_keys)
-                    g_key_set = set(normalized_g_keys)
-                    
-                    if p_key_set == g_key_set:
-                        # Perfect match
+                    normalized_p_keys = self.normalize_keys(p_val)
+                    normalized_g_keys = self.normalize_keys(g_keys)
+
+                    if normalized_p_keys == normalized_g_keys:
                         scores[g_type] += 1.0
                     else:
-                        # No match
                         scores[g_type] += 0.0
                 else:
                     # Fallback to exact match if not list comparison
                     scores[g_type] += 1.0 if p_val == g_keys else 0.0
 
             elif g_type == 'scroll':
-                # For scroll actions, we only care that the action type is 'scroll'
-                # No need to check direction or amount
-                scores[g_type] += 1.0
+                scores[g_type] += self.scroll_score(p_val, gt)
 
         # Calculate final scores
         for action_type in scores:
             scores[action_type] /= action_counts[action_type]
+            scores[action_type] *= action_count_penalty
 
         # Calculate total score as average of ground truth action scores
         action_score = sum(scores.values()) / len(scores) if scores else 0.0

--- a/evaluation/agentnetbench/test_eval.py
+++ b/evaluation/agentnetbench/test_eval.py
@@ -1,0 +1,83 @@
+import unittest
+
+from eval import ActionEvaluator
+
+
+def make_item(gt_actions, predicted_actions):
+    return {
+        "ground_truth_actions": gt_actions,
+        "predicted_actions": predicted_actions,
+    }
+
+
+class ActionEvaluatorValidityTests(unittest.TestCase):
+    def setUp(self):
+        self.evaluator = ActionEvaluator()
+
+    def test_import_does_not_require_editdistance_install(self):
+        self.assertEqual(self.evaluator.edit_distance("kitten", "sitting"), 3)
+
+    def test_scroll_wrong_direction_is_not_full_credit(self):
+        item = make_item(
+            [{"type": "scroll", "params": {"amount": -3}}],
+            [("scroll", 3)],
+        )
+
+        result = self.evaluator.evaluate_action(item)
+
+        self.assertEqual(result["total"], 0.0)
+        self.assertEqual(result["actions"]["scroll"], 0.0)
+
+    def test_scroll_same_direction_scores_amount_similarity(self):
+        item = make_item(
+            [{"type": "scroll", "params": {"amount": -6}}],
+            [("scroll", -3)],
+        )
+
+        result = self.evaluator.evaluate_action(item)
+
+        self.assertAlmostEqual(result["total"], 0.5)
+        self.assertAlmostEqual(result["actions"]["scroll"], 0.5)
+
+    def test_hotkey_order_is_not_ignored(self):
+        item = make_item(
+            [{"type": "hotkey", "params": {"keys": ["ctrl", "v"]}}],
+            [("hotkey", ["v", "ctrl"])],
+        )
+
+        result = self.evaluator.evaluate_action(item)
+
+        self.assertEqual(result["total"], 0.0)
+        self.assertEqual(result["actions"]["hotkey"], 0.0)
+
+    def test_repeated_key_count_is_not_ignored(self):
+        item = make_item(
+            [{"type": "press", "params": {"keys": ["down", "down"]}}],
+            [("press", ["down"])],
+        )
+
+        result = self.evaluator.evaluate_action(item)
+
+        self.assertEqual(result["total"], 0.0)
+        self.assertEqual(result["actions"]["press"], 0.0)
+
+    def test_extra_prediction_penalizes_otherwise_correct_action(self):
+        item = make_item(
+            [
+                {
+                    "type": "click",
+                    "params": {"position": {"x": 0.5, "y": 0.5}},
+                    "metadata": {"bboxes": []},
+                }
+            ],
+            [("click", (0.5, 0.5)), ("write", "unexpected")],
+        )
+
+        result = self.evaluator.evaluate_action(item)
+
+        self.assertAlmostEqual(result["total"], 0.5)
+        self.assertAlmostEqual(result["actions"]["click"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR tightens several AgentNetBench action-scoring edge cases and adds offline regression tests for them.

Changes:

- avoid installing `editdistance` at import time; use a built-in Levenshtein fallback if the optional package is missing
- score `scroll` actions by direction and amount instead of action type only
- compare `press` / `hotkey` key sequences while preserving order and repeated keys
- penalize extra predicted actions after an otherwise correct action

## Why

These edge cases can make an evaluator report overly optimistic scores:

- opposite-direction scrolls could receive full credit
- `["ctrl", "v"]` and `["v", "ctrl"]` were treated as equivalent because key comparison used sets
- repeated keys such as `["down", "down"]` could collapse to one key
- a correct first action followed by unrelated extra actions was not penalized
- importing the evaluator could mutate the runtime by installing a package

## Validation

From the repo root:

```bash
python3 evaluation/agentnetbench/test_eval.py
```

Result:

```text
Ran 6 tests in 0.001s
OK
```

I also checked unittest discovery:

```bash
python3 -m unittest discover evaluation/agentnetbench -p 'test_eval.py'
```

Result:

```text
Ran 6 tests in 0.003s
OK
```

The tests cover:

- missing optional `editdistance`
- wrong-direction scroll
- same-direction scroll amount similarity
- hotkey order mismatch
- repeated-key mismatch
- extra-action penalty

## Scope / limits

This PR does not change the model runner or sample data. It only updates local action scoring and adds offline regression coverage for the changed behavior.