### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Empirically, models trained with these rich CoTs scale better with data and gene
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xlang-ai/OpenCUA&type=date&legend=top-left)](https://www.star-history.com/#xlang-ai/OpenCUA&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xlang-ai/OpenCUA&type=date&legend=top-left)](https://star-history.dera.page/#xlang-ai/OpenCUA&type=date&legend=top-left)
 
 ## Acknowledge
 <p>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so the project's star history remains visible.